### PR TITLE
Add support for new flags XATTR_CREATE and XATTR_REPLACE

### DIFF
--- a/src/xattr.cr
+++ b/src/xattr.cr
@@ -5,7 +5,7 @@ require "./xattr/**"
 module XAttr
   VERSION = {{ `shards version "#{__DIR__}"`.chomp.stringify }}
 
-  def self.new(path : String, no_follow = false)
-    XAttr.new(path, no_follow: no_follow)
+  def self.new(path : String, no_follow = false, only_create = false, only_replace = false)
+    XAttr.new(path, no_follow: no_follow, only_create: only_create, only_replace: only_replace)
   end
 end

--- a/src/xattr/platforms/darwin.cr
+++ b/src/xattr/platforms/darwin.cr
@@ -11,6 +11,8 @@ module XAttr
       end
 
       XATTR_NOFOLLOW = 0x0001
+      XATTR_CREATE   = 0x0002 # set the value, fail if attr already exists
+      XATTR_REPLACE  = 0x0004 # set the value, fail if attr does not exist
 
       def self.get(path, key, value, size, no_follow)
         options = no_follow ? XATTR_NOFOLLOW : 0
@@ -18,8 +20,13 @@ module XAttr
         LibXAttr.getxattr(path, key, value, size, 0, options)
       end
 
-      def self.set(path, key, value, size, no_follow)
+      def self.set(path, key, value, size, no_follow, only_create, only_replace)
         options = no_follow ? XATTR_NOFOLLOW : 0
+
+        # If both XATTR_CREATE and XATTR_REPLACE are set
+        # then it raises EINVAL
+        options |= XATTR_CREATE if only_create
+        options |= XATTR_REPLACE if only_replace
 
         LibXAttr.setxattr(path, key, value, value.bytesize, 0, options)
       end

--- a/src/xattr/platforms/linux.cr
+++ b/src/xattr/platforms/linux.cr
@@ -14,6 +14,9 @@ module XAttr
         {% end %}
       end
 
+      XATTR_CREATE  = 0x1 # set value, fail if attr already exists
+      XATTR_REPLACE = 0x2 # set value, fail if attr does not exist
+
       def self.get(path, key, value, size, no_follow)
         if no_follow
           LibXAttr.lgetxattr(path, key, value, size)
@@ -22,11 +25,18 @@ module XAttr
         end
       end
 
-      def self.set(path, key, value, size, no_follow)
+      def self.set(path, key, value, size, no_follow, only_create, only_replace)
+        options = 0
+        # If both XATTR_CREATE and XATTR_REPLACE are set
+        # then it raises ENODATA if attribute not exists
+        # and EEXIST if attribute already exists.
+        options |= XATTR_CREATE if only_create
+        options |= XATTR_REPLACE if only_replace
+
         if no_follow
-          LibXAttr.lsetxattr(path, key, value, value.bytesize, 0)
+          LibXAttr.lsetxattr(path, key, value, value.bytesize, options)
         else
-          LibXAttr.setxattr(path, key, value, value.bytesize, 0)
+          LibXAttr.setxattr(path, key, value, value.bytesize, options)
         end
       end
 

--- a/src/xattr/xattr.cr
+++ b/src/xattr/xattr.cr
@@ -1,8 +1,10 @@
 module XAttr
   class XAttr
-    def initialize(path : String, no_follow = false)
+    def initialize(path : String, no_follow = false, only_create = false, only_replace = false)
       @path = path
       @no_follow = no_follow
+      @only_create = only_create
+      @only_replace = only_replace
     end
 
     def [](key)
@@ -18,7 +20,7 @@ module XAttr
     end
 
     def []=(key, value)
-      res = bindings.set(@path, key, value, value.bytesize, @no_follow)
+      res = bindings.set(@path, key, value, value.bytesize, @no_follow, @only_create, @only_replace)
       raise_error(res) if res == -1
 
       res


### PR DESCRIPTION
* `XATTR_CREATE` - set the value, fail if attr already exists.
* `XATTR_REPLACE` - set the value, fail if attr does not exist.

Signed-off-by: Aravinda Vishwanathapura <mail@aravindavk.in>